### PR TITLE
Remove TrafficDataHandler when HUB_TOKEN is absent

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,11 +1,15 @@
 import os
+SECRET_KEY = os.environ.get("HUB_TOKEN", False)
+if SECRET_KEY:
+    from helper.utils import TrafficDataHandler
+    
 import uuid
 
 import gradio as gr
 
 from helper.gradio_config import css, theme
 from helper.text.text_app import TextApp
-from helper.utils import TrafficDataHandler
+
 from tabs.htr_tool import htr_tool_tab
 from tabs.overview_tab import overview
 from tabs.stepwise_htr_tool import stepwise_htr_tool_tab
@@ -46,7 +50,6 @@ with gr.Blocks(title="Riksarkivet", theme=theme, css=css) as demo:
                         format="mp4",
                     )
 
-    SECRET_KEY = os.environ.get("HUB_TOKEN", False)
     if SECRET_KEY:
         demo.load(
             fn=TrafficDataHandler.onload_store_metric_data,

--- a/tabs/htr_tool.py
+++ b/tabs/htr_tool.py
@@ -1,9 +1,11 @@
 import os
-
+SECRET_KEY = os.environ.get("HUB_TOKEN", False)
+if SECRET_KEY:
+    from helper.utils import TrafficDataHandler
+    
 import gradio as gr
 
 from helper.examples.examples import DemoImages
-from helper.utils import TrafficDataHandler
 from src.htr_pipeline.gradio_backend import (
     FastTrack,
     SingletonModelLoader,

--- a/tabs/stepwise_htr_tool.py
+++ b/tabs/stepwise_htr_tool.py
@@ -1,4 +1,8 @@
 import os
+SECRET_KEY = os.environ.get("HUB_TOKEN", False)
+if SECRET_KEY:
+    from helper.utils import TrafficDataHandler
+    
 import shutil
 from difflib import Differ
 
@@ -6,7 +10,6 @@ import evaluate
 import gradio as gr
 
 from helper.examples.examples import DemoImages
-from helper.utils import TrafficDataHandler
 from src.htr_pipeline.gradio_backend import CustomTrack, SingletonModelLoader
 
 model_loader = SingletonModelLoader()


### PR DESCRIPTION
This pull request addresses the issue of starting app.py when the necessary privileges to push/pull from the Riksarkivet Hugging Face repository are missing.

If HUB_TOKEN is set the import of TrafficDataHandler continues as before.